### PR TITLE
Add autojar build packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,6 +267,7 @@ task cliAutojar(type: Autojar, dependsOn: prepareJodaTimezones) {
             "com/amazonaws/sdk/versionInfo.properties",
             "com/amazonaws/regions/regions.xml",
             "awssdk_config_default.json",
+            "rdsecho.properties.sample",
             "logback.xml"]
 
     prepareJodaTimezones.outputs.files.each {


### PR DESCRIPTION
This should plop out a nice 5.1 MB executable uberjar. We'll want to test running through some of the functionality to make sure it doesn't skip any critical dependencies that are  dynamically loaded, but it seems to be working.
