### PR TITLE
Add additional missing autojar files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,7 @@ task cliAutojar(type: Autojar, dependsOn: prepareJodaTimezones) {
     autojarFiles = [
             "com/amazonaws/sdk/versionInfo.properties",
             "com/amazonaws/regions/regions.xml",
+            "com/amazonaws/services/route53/request.handlers",
             "awssdk_config_default.json",
             "rdsecho.properties.sample",
             "simplelogger.properties"]
@@ -259,7 +260,8 @@ task cliAutojar(type: Autojar, dependsOn: prepareJodaTimezones) {
             "org.apache.commons.logging.impl.SimpleLog",
             "org.apache.commons.logging.impl.LogFactoryImpl",
             "com.amazonaws.internal.config.HttpClientConfigJsonHelper",
-            "com.amazonaws.internal.config.HostRegexToRegionMappingJsonHelper"]
+            "com.amazonaws.internal.config.HostRegexToRegionMappingJsonHelper",
+            "com.amazonaws.services.route53.internal.Route53IdRequestHandler"]
 
     doFirst {
         prepareJodaTimezones.outputs.files.each {


### PR DESCRIPTION
Autojar wasn't able to detect that we needed `com/amazonaws/services/route53/request.handlers` which has a single line that points to `com.amazonaws.services.route53.internal.Route53IdRequestHandler`. So let's just add them. This should fix the brokenness around `rds-echo promote`.