### PR TITLE
Apply custom tags on new and promote

### DIFF
--- a/src/main/java/com/github/blacklocus/rdsecho/EchoCfg.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoCfg.java
@@ -55,6 +55,7 @@ public class EchoCfg {
     public static final String PROP_NEW_PORT = PREFIX + "new.port";
     public static final String PROP_NEW_OPTION_GROUP_NAME = PREFIX + "new.optionGroupName";
     public static final String PROP_NEW_AUTO_MINOR_VERSION_UPGRADE = PREFIX + "new.autoMinorVersionUpgrade";
+    public static final String PROP_NEW_TAGS = PREFIX + "new.tags";
 
     // Modify parameters are mostly optional
     public static final String PROP_MOD_DB_PARAMETER_GROUP_NAME = PREFIX + "mod.dbParameterGroupName";
@@ -168,6 +169,14 @@ public class EchoCfg {
         return cfg.getBoolean(PROP_NEW_AUTO_MINOR_VERSION_UPGRADE);
     }
 
+    public Optional<String[]> newTags() {
+        String[] values = cfg.getStringArray(PROP_NEW_TAGS);
+        if (values == null || values.length == 0) {
+            return Optional.absent();
+        } else {
+            return Optional.of(values);
+        }
+    }
 
     public Optional<String> modDbParameterGroupName() {
         return Optional.fromNullable(cfg.getString(PROP_MOD_DB_PARAMETER_GROUP_NAME));

--- a/src/main/java/com/github/blacklocus/rdsecho/EchoCfg.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoCfg.java
@@ -65,6 +65,7 @@ public class EchoCfg {
     // Promote parameters are required
     public static final String PROP_PROMOTE_CNAME = PREFIX + "promote.cname";
     public static final String PROP_PROMOTE_TTL = PREFIX + "promote.ttl";
+    public static final String PROP_PROMOTE_TAGS = PREFIX + "promote.tags";
 
     // Retire parameters are optional and unspecified take on AWS defaults
     public static final String PROP_RETIRE_SKIP_FINAL_SNAPSHOT = PREFIX + "retire.skipFinalSnapshot";
@@ -91,15 +92,16 @@ public class EchoCfg {
     };
     final CompositeConfiguration cfg;
 
-    private EchoCfg() {
+    // package scoped for testing
+    EchoCfg(String propertiesFilename) {
         this.cfg = new CompositeConfiguration();
         this.cfg.addConfiguration(new SystemConfiguration());
         try {
-            this.cfg.addConfiguration(new PropertiesConfiguration(EchoConst.CONFIGURATION_PROPERTIES));
-            LOG.info("Reading configuration from {}", EchoConst.CONFIGURATION_PROPERTIES);
+            this.cfg.addConfiguration(new PropertiesConfiguration(propertiesFilename));
+            LOG.info("Reading configuration from {}", propertiesFilename);
 
         } catch (ConfigurationException e) {
-            LOG.info("{} will not be read because {}", EchoConst.CONFIGURATION_PROPERTIES, e.getMessage());
+            LOG.info("{} will not be read because {}", propertiesFilename, e.getMessage());
         }
         validate();
     }
@@ -196,6 +198,15 @@ public class EchoCfg {
         return cfg.getLong(PROP_PROMOTE_TTL);
     }
 
+    public Optional<String[]> promoteTags() {
+        String[] values = cfg.getStringArray(PROP_PROMOTE_TAGS);
+        if (values == null || values.length == 0) {
+            return Optional.absent();
+        } else {
+            return Optional.of(values);
+        }
+    }
+
     public Optional<Boolean> retireSkipFinalSnapshot() {
         return Optional.fromNullable(cfg.getBoolean(PROP_RETIRE_SKIP_FINAL_SNAPSHOT, null));
     }
@@ -205,7 +216,7 @@ public class EchoCfg {
     }
 
     public static final class Lazy {
-        static final EchoCfg INSTANCE = new EchoCfg();
+        static final EchoCfg INSTANCE = new EchoCfg(EchoConst.CONFIGURATION_PROPERTIES);
     }
 
     public static EchoCfg getInstance() {

--- a/src/main/java/com/github/blacklocus/rdsecho/EchoPromote.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoPromote.java
@@ -114,7 +114,7 @@ public class EchoPromote extends AbstractEchoIntermediateStage {
         if (promoteTags.isPresent()) {
             List<Tag> tags = EchoUtil.parseTags(promoteTags.get());
             if (tags.size() > 0) {
-                LOG.info("Applying tags: {}", Arrays.asList(tags));
+                LOG.info("Applying tags on promote: {}", Arrays.asList(tags));
                 AddTagsToResourceRequest tagsRequest = new AddTagsToResourceRequest()
                         .withResourceName(RdsFind.instanceArn(cfg.region(), cfg.accountNumber(),
                                 instance.getDBInstanceIdentifier()));

--- a/src/main/java/com/github/blacklocus/rdsecho/EchoPromote.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoPromote.java
@@ -23,8 +23,10 @@
  */
 package com.github.blacklocus.rdsecho;
 
+import com.amazonaws.services.rds.model.AddTagsToResourceRequest;
 import com.amazonaws.services.rds.model.DBInstance;
 import com.amazonaws.services.rds.model.Endpoint;
+import com.amazonaws.services.rds.model.Tag;
 import com.amazonaws.services.route53.AmazonRoute53;
 import com.amazonaws.services.route53.AmazonRoute53Client;
 import com.amazonaws.services.route53.model.Change;
@@ -36,9 +38,14 @@ import com.amazonaws.services.route53.model.RRType;
 import com.amazonaws.services.route53.model.ResourceRecord;
 import com.amazonaws.services.route53.model.ResourceRecordSet;
 import com.github.blacklocus.rdsecho.utl.EchoUtil;
+import com.github.blacklocus.rdsecho.utl.RdsFind;
 import com.github.blacklocus.rdsecho.utl.Route53Find;
+import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static com.github.blacklocus.rdsecho.utl.Route53Find.cnameEquals;
 import static com.github.blacklocus.rdsecho.utl.Route53Find.nameEquals;
@@ -103,8 +110,20 @@ public class EchoPromote extends AbstractEchoIntermediateStage {
                                 .withTTL(cfg.promoteTtl()))));
         route53.changeResourceRecordSets(request);
 
-        LOG.info("Searching for any existing promoted instance to demote.");
+        Optional<String[]> promoteTags = cfg.promoteTags();
+        if (promoteTags.isPresent()) {
+            List<Tag> tags = EchoUtil.parseTags(promoteTags.get());
+            if (tags.size() > 0) {
+                LOG.info("Applying tags: {}", Arrays.asList(tags));
+                AddTagsToResourceRequest tagsRequest = new AddTagsToResourceRequest()
+                        .withResourceName(RdsFind.instanceArn(cfg.region(), cfg.accountNumber(),
+                                instance.getDBInstanceIdentifier()));
+                tagsRequest.setTags(tags);
+                rds.addTagsToResource(tagsRequest);
+            }
+        }
 
+        LOG.info("Searching for any existing promoted instance to demote.");
 
         return true;
     }

--- a/src/main/java/com/github/blacklocus/rdsecho/utl/EchoUtil.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/utl/EchoUtil.java
@@ -30,12 +30,14 @@ import com.github.blacklocus.rdsecho.EchoCfg;
 import com.github.blacklocus.rdsecho.EchoConst;
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.List;
 
 public class EchoUtil {
 
@@ -88,5 +90,16 @@ public class EchoUtil {
         } catch (IOException e) {
             throw new RuntimeException();
         }
+    }
+
+    public static List<Tag> parseTags(String[] rawTags) {
+        List<Tag> tags = Lists.newArrayList();
+        for(String rawTag : rawTags) {
+            String[] splitTag = rawTag.split("=", 2);
+            if(splitTag.length == 2) {
+                tags.add(new Tag().withKey(splitTag[0]).withValue(splitTag[1]));
+            }
+        }
+        return tags;
     }
 }

--- a/src/main/resources/rdsecho.properties.sample
+++ b/src/main/resources/rdsecho.properties.sample
@@ -58,7 +58,8 @@ rdsecho.mod.applyImmediately=true
 # fashion of DNS records.
 rdsecho.promote.cname=dev.domain.com.
 rdsecho.promote.ttl=300
-
+# Apply one or more tags to the instance once it has been promoted
+rdsecho.promote.tags=development=yes,banana=no
 
 
 # Retirement

--- a/src/main/resources/rdsecho.properties.sample
+++ b/src/main/resources/rdsecho.properties.sample
@@ -39,7 +39,7 @@ rdsecho.new.iops=0
 rdsecho.new.port=3306
 rdsecho.new.optionGroupName=default:mysql-5-6
 rdsecho.new.autoMinorVersionUpgrade=true
-
+rdsecho.new.tags=orange=false,pear=maybe
 
 
 # Modify instance API parameters

--- a/src/test/java/com/github/blacklocus/rdsecho/EchoCfgTest.java
+++ b/src/test/java/com/github/blacklocus/rdsecho/EchoCfgTest.java
@@ -1,0 +1,22 @@
+package com.github.blacklocus.rdsecho;
+
+import com.google.common.base.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class EchoCfgTest {
+
+    @Test
+    public void checkSample() {
+        EchoCfg cfg = new EchoCfg("rdsecho.properties.sample");
+
+        Optional<String[]> tags = cfg.promoteTags();
+        Assert.assertTrue(tags.isPresent());
+
+        String[] allTags = tags.get();
+        Assert.assertEquals(2, allTags.length);
+
+        Assert.assertEquals("development=yes", allTags[0]);
+        Assert.assertEquals("banana=no", allTags[1]);
+    }
+}

--- a/src/test/java/com/github/blacklocus/rdsecho/EchoCfgTest.java
+++ b/src/test/java/com/github/blacklocus/rdsecho/EchoCfgTest.java
@@ -10,13 +10,22 @@ public class EchoCfgTest {
     public void checkSample() {
         EchoCfg cfg = new EchoCfg("rdsecho.properties.sample");
 
-        Optional<String[]> tags = cfg.promoteTags();
-        Assert.assertTrue(tags.isPresent());
+        Optional<String[]> newTags = cfg.newTags();
+        Assert.assertTrue(newTags.isPresent());
 
-        String[] allTags = tags.get();
-        Assert.assertEquals(2, allTags.length);
+        String[] allNewTags = newTags.get();
+        Assert.assertEquals(2, allNewTags.length);
 
-        Assert.assertEquals("development=yes", allTags[0]);
-        Assert.assertEquals("banana=no", allTags[1]);
+        Assert.assertEquals("orange=false", allNewTags[0]);
+        Assert.assertEquals("pear=maybe", allNewTags[1]);
+
+        Optional<String[]> promoteTags = cfg.promoteTags();
+        Assert.assertTrue(promoteTags.isPresent());
+
+        String[] allPromoteTags = promoteTags.get();
+        Assert.assertEquals(2, allPromoteTags.length);
+
+        Assert.assertEquals("development=yes", allPromoteTags[0]);
+        Assert.assertEquals("banana=no", allPromoteTags[1]);
     }
 }

--- a/src/test/java/com/github/blacklocus/rdsecho/utl/EchoUtilTest.java
+++ b/src/test/java/com/github/blacklocus/rdsecho/utl/EchoUtilTest.java
@@ -1,0 +1,30 @@
+package com.github.blacklocus.rdsecho.utl;
+
+import com.amazonaws.services.rds.model.Tag;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class EchoUtilTest {
+
+    @Test
+    public void parseTags() {
+        String[] rawTags = {"development=yes", "potato=no", "tomato", "pterodactyl=well=maybe"};
+        List<Tag> tags = EchoUtil.parseTags(rawTags);
+
+        Assert.assertEquals(3, tags.size());
+
+        Tag one = tags.get(0);
+        Assert.assertEquals("development", one.getKey());
+        Assert.assertEquals("yes", one.getValue());
+
+        Tag two = tags.get(1);
+        Assert.assertEquals("potato", two.getKey());
+        Assert.assertEquals("no", two.getValue());
+
+        Tag three = tags.get(2);
+        Assert.assertEquals("pterodactyl", three.getKey());
+        Assert.assertEquals("well=maybe", three.getValue());
+    }
+}


### PR DESCRIPTION
This adds some custom tagging to the `new` and `promote` stages. We should now be able to add one or more tags to an instance during either or both of these events as well as test the rest of the `EchoCfg` properties in the `rdsecho.properties.sample` more easily.