### PR TITLE
Update logging to specify which command is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ DB instance in the "available" state.
 
 All rds-echo state tracking metadata is stored as AWS resource tags on the RDS instance themselves
 
-
+For more information on when rebooting after modifying is necessary, see the [AWS documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.html#Overview.DBInstance.Modifying).
 
 ## Futures ##
 

--- a/src/main/java/com/github/blacklocus/rdsecho/Echo.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/Echo.java
@@ -24,9 +24,6 @@
 package com.github.blacklocus.rdsecho;
 
 import com.google.common.collect.ImmutableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -35,6 +32,20 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.blacklocus.rdsecho.EchoConst.COMMAND_MODIFY;
+import static com.github.blacklocus.rdsecho.EchoConst.COMMAND_NEW;
+import static com.github.blacklocus.rdsecho.EchoConst.COMMAND_PROMOTE;
+import static com.github.blacklocus.rdsecho.EchoConst.COMMAND_REBOOT;
+import static com.github.blacklocus.rdsecho.EchoConst.COMMAND_RETIRE;
+import static com.github.blacklocus.rdsecho.EchoConst.STAGE_FORGOTTEN;
+import static com.github.blacklocus.rdsecho.EchoConst.STAGE_MODIFIED;
+import static com.github.blacklocus.rdsecho.EchoConst.STAGE_NEW;
+import static com.github.blacklocus.rdsecho.EchoConst.STAGE_PROMOTED;
+import static com.github.blacklocus.rdsecho.EchoConst.STAGE_REBOOTED;
+import static com.github.blacklocus.rdsecho.EchoConst.STAGE_RETIRED;
 
 public class Echo {
 
@@ -50,22 +61,22 @@ public class Echo {
                             "present in the current directory, OPTS property values will be populated with the file's " +
                             "values. The stdout of this command can be piped to a file. Log messages are placed on " +
                             "stderr and so will not be included in the output."))
-            .put("new", bundle(EchoNew.class,
+            .put(COMMAND_NEW, bundle(EchoNew.class,
                     "Creates a stage '%s' instance from a snapshot. This is usually the longest operation.",
-                    EchoConst.STAGE_NEW))
-            .put("modify", bundle(EchoModify.class,
+                    STAGE_NEW))
+            .put(COMMAND_MODIFY, bundle(EchoModify.class,
                     "Modifies a stage '%s' instance with remaining settings that could not be applied on create and advances stage to '%s'.",
-                    EchoConst.STAGE_NEW, EchoConst.STAGE_MODIFIED))
-            .put("reboot", bundle(EchoReboot.class,
+                    STAGE_NEW, STAGE_MODIFIED))
+            .put(COMMAND_REBOOT, bundle(EchoReboot.class,
                     "Reboots a stage '%s' instance so that all settings may take full effect and advances stage to '%s'.",
-                    EchoConst.STAGE_MODIFIED, EchoConst.STAGE_REBOOTED))
-            .put("promote", bundle(EchoPromote.class,
+                    STAGE_MODIFIED, STAGE_REBOOTED))
+            .put(COMMAND_PROMOTE, bundle(EchoPromote.class,
                     "Promotes a stage '%s' instance so that it becomes the active instance behind the specified CNAME " +
                             "and advances stage to '%s'. Any previously '%s' instances will be moved to stage '%s'.",
-                    EchoConst.STAGE_REBOOTED, EchoConst.STAGE_PROMOTED, EchoConst.STAGE_PROMOTED, EchoConst.STAGE_FORGOTTEN))
-            .put("retire", bundle(EchoRetire.class,
+                    STAGE_REBOOTED, STAGE_PROMOTED, STAGE_PROMOTED, STAGE_FORGOTTEN))
+            .put(COMMAND_RETIRE, bundle(EchoRetire.class,
                     "Retires a stage '%s' instance (destroys it) and advances stage to '%s'.",
-                    EchoConst.STAGE_FORGOTTEN, EchoConst.STAGE_RETIRED))
+                    STAGE_FORGOTTEN, STAGE_RETIRED))
             .build();
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/com/github/blacklocus/rdsecho/EchoConst.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoConst.java
@@ -77,4 +77,30 @@ public class EchoConst {
      * being destroyed or will be soon.
      */
     public static final String STAGE_RETIRED = "retired";
+
+    /**
+     * The command to create a new instance. Sets stage as "new"
+     */
+    public static final String COMMAND_NEW = "new";
+
+    /**
+     * The command to modify an existing instance. Changes stage from "new" to "modified"
+     */
+    public static final String COMMAND_MODIFY = "modify";
+
+    /**
+     * The command to reboot an instance after it has been modified. Changes stage from "modified" to "rebooted"
+     */
+    public static final String COMMAND_REBOOT = "reboot";
+
+    /**
+     * The command to promote an instance that is ready for use. Changes stage from "rebooted" to "promoted".
+     * Changes previously promoted instance to "forgotten".
+     */
+    public static final String COMMAND_PROMOTE = "promote";
+
+    /**
+     * The command to retire an instance. Changes stage from "forgotten" to "retired" and then deletes it. Goodbye forever.
+     */
+    public static final String COMMAND_RETIRE = "retire";
 }

--- a/src/main/java/com/github/blacklocus/rdsecho/EchoModify.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoModify.java
@@ -46,10 +46,11 @@ public class EchoModify extends AbstractEchoIntermediateStage {
     boolean traverseStage(DBInstance instance) {
 
         // Prepare request and build up informational message with conditional parts.
+        String dbInstanceId = instance.getDBInstanceIdentifier();
 
         StringWriter proposed = new StringWriter();
         PrintWriter printer = new PrintWriter(proposed);
-        printer.format("Proposed db modifications...%n");
+        printer.format("[%s] Proposed db modifications on instance %s...%n", getCommand(), dbInstanceId);
 
         ModifyDBInstanceRequest request = new ModifyDBInstanceRequest();
         request.withDBInstanceIdentifier(instance.getDBInstanceIdentifier());
@@ -79,7 +80,6 @@ public class EchoModify extends AbstractEchoIntermediateStage {
 
         if (cfg.interactive()) {
             String format = "Proceed to modify DB instance with these settings? Input %s to confirm.";
-            String dbInstanceId = instance.getDBInstanceIdentifier();
             if (!EchoUtil.prompt(dbInstanceId, format, dbInstanceId)) {
                 LOG.info("User declined to proceed. Exiting.");
                 return false;
@@ -88,13 +88,16 @@ public class EchoModify extends AbstractEchoIntermediateStage {
 
         // Do the deed
 
-        LOG.info("Modifying existing DB instance.");
+        LOG.info("[{}] Modifying existing DB instance {}", getCommand(), dbInstanceId);
         rds.modifyDBInstance(request);
-        LOG.info("Submitted instance modify request. The instance may need to be rebooted to receive the effect of " +
-                "certain settings. See AWS RDS documentation for details:\n" +
-                "http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.html#Overview.DBInstance.Modifying");
+        LOG.info("[{}] Submitted modify request on instance {}. Finished.", getCommand(), dbInstanceId);
 
         return true;
+    }
+
+    @Override
+    String getCommand() {
+        return EchoConst.COMMAND_MODIFY;
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/com/github/blacklocus/rdsecho/EchoNew.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoNew.java
@@ -34,14 +34,15 @@ import com.amazonaws.services.rds.model.Tag;
 import com.github.blacklocus.rdsecho.utl.EchoUtil;
 import com.github.blacklocus.rdsecho.utl.RdsFind;
 import com.google.common.base.Optional;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Callable;
+import static com.github.blacklocus.rdsecho.EchoConst.COMMAND_NEW;
 
 public class EchoNew implements Callable<Boolean> {
 
@@ -59,36 +60,36 @@ public class EchoNew implements Callable<Boolean> {
 
         String tagEchoManaged = echo.getTagEchoManaged();
 
-        LOG.info("Checking to see if current echo-created instance (tagged {}) was created less than 24 hours ago. " +
-                "If so this operation will not continue.", tagEchoManaged);
+        LOG.info("[{}] Checking to see if current echo-created instance (tagged {}) was created less than 24 hours ago. " +
+                "If so this operation will not continue.", COMMAND_NEW, tagEchoManaged);
         Optional<DBInstance> newestInstanceOpt = echo.lastEchoInstance();
         if (newestInstanceOpt.isPresent()) {
 
             if (new DateTime(newestInstanceOpt.get().getInstanceCreateTime()).plusHours(24).isAfter(DateTime.now())) {
-                LOG.info("  Last echo-created RDS instance {} was created less than 24 hours ago. Aborting.",
-                        tagEchoManaged);
+                LOG.info("[{}] Last echo-created RDS instance {} was created less than 24 hours ago. Aborting.",
+                        COMMAND_NEW, tagEchoManaged);
                 return false;
 
             } else {
-                LOG.info("  Last echo-created RDS instance {} was created more than 24 hours ago. Proceeding.",
-                        tagEchoManaged);
+                LOG.info("[{}] Last echo-created RDS instance {} was created more than 24 hours ago. Proceeding.",
+                        COMMAND_NEW, tagEchoManaged);
             }
 
         } else {
-            LOG.info("  No prior echo-created instance found with tag {}. Proceeding.", tagEchoManaged);
+            LOG.info("[{}] No prior echo-created instance found with tag {}. Proceeding.", COMMAND_NEW, tagEchoManaged);
         }
 
         // Locate a suitable snapshot to be the basis of the new instance
 
-        LOG.info("Locating latest snapshot from {}", cfg.snapshotDbInstanceIdentifier());
+        LOG.info("[{}] Locating latest snapshot from {}", COMMAND_NEW, cfg.snapshotDbInstanceIdentifier());
         Optional<DBSnapshot> dbSnapshotOpt = echo.latestSnapshot();
         if (dbSnapshotOpt.isPresent()) {
             DBSnapshot snapshot = dbSnapshotOpt.get();
-            LOG.info("  Located snapshot {} completed on {}", snapshot.getDBSnapshotIdentifier(),
+            LOG.info("[{}] Located snapshot {} completed on {}", COMMAND_NEW, snapshot.getDBSnapshotIdentifier(),
                     new DateTime(snapshot.getSnapshotCreateTime()).toDateTimeISO().toString());
 
         } else {
-            LOG.info("  Could not locate a suitable snapshot. Cannot continue.");
+            LOG.info("[{}] Could not locate a suitable snapshot. Cannot continue.", COMMAND_NEW);
             return false;
         }
 
@@ -96,7 +97,7 @@ public class EchoNew implements Callable<Boolean> {
 
         String dbSnapshotIdentifier = dbSnapshotOpt.get().getDBSnapshotIdentifier();
         String newDbInstanceIdentifier = cfg.name() + '-' + DateTime.now(DateTimeZone.UTC).toString("yyyy-MM-dd");
-        LOG.info("Proposed new db instance...\n" +
+        LOG.info("[{}] Proposed new db instance...\n" +
                         "  engine           : {}\n" +
                         "  license model    : {}\n" +
                         "  db instance class: {}\n" +
@@ -108,6 +109,7 @@ public class EchoNew implements Callable<Boolean> {
                         "  port             : {}\n" +
                         "  option group name: {}\n" +
                         "  auto minor ver up: {}",
+                COMMAND_NEW,
                 cfg.newEngine(),
                 cfg.newLicenseModel(),
                 cfg.newDbInstanceClass(),
@@ -132,7 +134,7 @@ public class EchoNew implements Callable<Boolean> {
 
         // Create the new database
 
-        LOG.info("Creating new DB instance. Hold on to your butts.");
+        LOG.info("[{}] Creating new DB instance. Hold on to your butts.", COMMAND_NEW);
         RestoreDBInstanceFromDBSnapshotRequest request = new RestoreDBInstanceFromDBSnapshotRequest()
                 .withEngine(cfg.newEngine())
                 .withLicenseModel(cfg.newLicenseModel())
@@ -155,7 +157,7 @@ public class EchoNew implements Callable<Boolean> {
         if (newTags.isPresent()) {
             List<Tag> tags = EchoUtil.parseTags(newTags.get());
             if (tags.size() > 0) {
-                LOG.info("Applying tags on create new: {}", Arrays.asList(tags));
+                LOG.info("[{}] Applying tags on create new: {}", COMMAND_NEW, Arrays.asList(tags));
                 AddTagsToResourceRequest tagsRequest = new AddTagsToResourceRequest()
                         .withResourceName(RdsFind.instanceArn(cfg.region(), cfg.accountNumber(),
                                 restoredInstance.getDBInstanceIdentifier()));
@@ -164,10 +166,9 @@ public class EchoNew implements Callable<Boolean> {
             }
         }
 
-        LOG.info("Created new DB instance. \n" +
-                        "  https://console.aws.amazon.com/rds/home?region={}#dbinstance:id={}\n" +
-                        "Additional preparation of the instance will continue once the instance becomes available.",
-                cfg.region(), newDbInstanceIdentifier);
+        LOG.info("[{}] Kicked off new DB instance creation. All done here. Check on your instance progress at\n" +
+                        "  https://console.aws.amazon.com/rds/home?region={}#dbinstance:id={}",
+                COMMAND_NEW, cfg.region(), newDbInstanceIdentifier);
 
         return true;
     }

--- a/src/main/java/com/github/blacklocus/rdsecho/EchoReboot.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoReboot.java
@@ -49,11 +49,16 @@ public class EchoReboot extends AbstractEchoIntermediateStage {
             }
         }
 
-        LOG.info("Rebooting instance {}", dbInstanceId);
+        LOG.info("[{}] Rebooting instance {}", getCommand(), dbInstanceId);
         rds.rebootDBInstance(new RebootDBInstanceRequest()
                 .withDBInstanceIdentifier(dbInstanceId));
 
         return true;
+    }
+
+    @Override
+    String getCommand() {
+        return EchoConst.COMMAND_REBOOT;
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/com/github/blacklocus/rdsecho/EchoRetire.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoRetire.java
@@ -41,7 +41,7 @@ public class EchoRetire extends AbstractEchoIntermediateStage {
     boolean traverseStage(DBInstance instance) {
 
         String dbInstanceId = instance.getDBInstanceIdentifier();
-        LOG.info("Propose to retire (destroy) instance {}", dbInstanceId);
+        LOG.info("[{}] Propose to retire (destroy) instance {}", getCommand(), dbInstanceId);
 
         if (cfg.interactive()) {
             String format = "Are you sure you want to retire this instance? Input %s to confirm.";
@@ -51,15 +51,20 @@ public class EchoRetire extends AbstractEchoIntermediateStage {
             }
         }
 
-        LOG.info("Retiring instance {}", dbInstanceId);
+        LOG.info("[{}] Retiring instance {}", getCommand(), dbInstanceId);
         DeleteDBInstanceRequest request = new DeleteDBInstanceRequest()
                 .withDBInstanceIdentifier(dbInstanceId)
                 .withSkipFinalSnapshot(cfg.retireSkipFinalSnapshot().orNull())
                 .withFinalDBSnapshotIdentifier(cfg.retireFinalDbSnapshotIdentifier().orNull());
         rds.deleteDBInstance(request);
-        LOG.info("So long {}", dbInstanceId);
+        LOG.info("[{}] So long {}", getCommand(), dbInstanceId);
 
         return true;
+    }
+
+    @Override
+    String getCommand() {
+        return EchoConst.COMMAND_RETIRE;
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Most of the logging output among these classes were very similar, and it was unclear whether something was actually an error or not. For example, if `promote` was run but we found an instance that was managed but in the `new` state, it erroneously appeared that we encountered an error. Logging is now updated to more clearly indicate that desired behavior is for the program to cleanly exit when it doesn't find a database that it's supposed to do work on.

It was also unclear which command was running at a given time, since all commands except `new` share the same parent abstract class. Investigating a legitimate error was difficult because the logs couldn't be deciphered to tell which command was problematic. Now each log line is labeled with its input command.

Also also several lines of the logging were better suited for the readme, so they've been shortened and the readme was updated where appropriate.

No business logic changes. :briefcase: 