### PR TITLE
Allow optional parameters for new instance creation

### DIFF
--- a/src/main/java/com/github/blacklocus/rdsecho/EchoCfg.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoCfg.java
@@ -78,15 +78,6 @@ public class EchoCfg {
             PROP_REGION,
             PROP_ACCOUNT_NUMBER,
             PROP_SNAPSHOT_DB_INSTANCE_IDENTIFIER,
-            PROP_NEW_ENGINE,
-            PROP_NEW_LICENSE_MODEL,
-            PROP_NEW_DB_INSTANCE_CLASS,
-            PROP_NEW_MULTI_AZ,
-            PROP_NEW_STORAGE_TYPE,
-            PROP_NEW_IOPS,
-            PROP_NEW_PORT,
-            PROP_NEW_OPTION_GROUP_NAME,
-            PROP_NEW_AUTO_MINOR_VERSION_UPGRADE,
             PROP_MOD_APPLY_IMMEDIATELY,
             PROP_PROMOTE_CNAME,
             PROP_PROMOTE_TTL,
@@ -133,40 +124,40 @@ public class EchoCfg {
         return cfg.getString(PROP_SNAPSHOT_DB_INSTANCE_IDENTIFIER);
     }
 
-    public String newEngine() {
-        return cfg.getString(PROP_NEW_ENGINE);
+    public Optional<String> newEngine() {
+        return Optional.fromNullable(cfg.getString(PROP_NEW_ENGINE));
     }
 
-    public String newLicenseModel() {
-        return cfg.getString(PROP_NEW_LICENSE_MODEL);
+    public Optional<String> newLicenseModel() {
+        return Optional.fromNullable(cfg.getString(PROP_NEW_LICENSE_MODEL));
     }
 
-    public String newDbInstanceClass() {
-        return cfg.getString(PROP_NEW_DB_INSTANCE_CLASS);
+    public Optional<String> newDbInstanceClass() {
+        return Optional.fromNullable(cfg.getString(PROP_NEW_DB_INSTANCE_CLASS));
     }
 
-    public boolean newMultiAz() {
-        return cfg.getBoolean(PROP_NEW_MULTI_AZ);
+    public Optional<Boolean> newMultiAz() {
+        return Optional.fromNullable(cfg.getBoolean(PROP_NEW_MULTI_AZ, null));
     }
 
-    public String newStorageType() {
-        return cfg.getString(PROP_NEW_STORAGE_TYPE);
+    public Optional<String> newStorageType() {
+        return Optional.fromNullable(cfg.getString(PROP_NEW_STORAGE_TYPE));
     }
 
-    public int newIops() {
-        return cfg.getInt(PROP_NEW_IOPS);
+    public Optional<Integer> newIops() {
+        return Optional.fromNullable(cfg.getInteger(PROP_NEW_IOPS, null));
     }
 
-    public int newPort() {
-        return cfg.getInt(PROP_NEW_PORT);
+    public Optional<Integer> newPort() {
+        return Optional.fromNullable(cfg.getInteger(PROP_NEW_PORT, null));
     }
 
-    public String newOptionGroupName() {
-        return cfg.getString(PROP_NEW_OPTION_GROUP_NAME);
+    public Optional<String> newOptionGroupName() {
+        return Optional.fromNullable(cfg.getString(PROP_NEW_OPTION_GROUP_NAME));
     }
 
-    public boolean newAutoMinorVersionUpgrade() {
-        return cfg.getBoolean(PROP_NEW_AUTO_MINOR_VERSION_UPGRADE);
+    public Optional<Boolean> newAutoMinorVersionUpgrade() {
+        return Optional.fromNullable(cfg.getBoolean(PROP_NEW_AUTO_MINOR_VERSION_UPGRADE, null));
     }
 
     public Optional<String[]> newTags() {


### PR DESCRIPTION
Changes 9 parameters from being required to being optional during new instance creation. If the parameter does not exist in the run configurations, do not send it at all in the AWS API call. There are no default values sent to AWS.  This change works because AWS will supplement the missing information with the values of the snapshot being cloned into the new instance.

This change does not check or enforce any AWS API restrictions, such as requiring IOPS if the storage type is set, etc.

Optional-ness of parameters taken from [API](http://docs.aws.amazon.com//AmazonRDS/latest/APIReference/API_RestoreDBInstanceFromDBSnapshot.html)
