### PR TITLE
Update logging message for config loading

### DIFF
--- a/src/main/java/com/github/blacklocus/rdsecho/EchoCfg.java
+++ b/src/main/java/com/github/blacklocus/rdsecho/EchoCfg.java
@@ -102,7 +102,7 @@ public class EchoCfg {
             LOG.info("Reading configuration from {}", propertiesFilename);
 
         } catch (ConfigurationException e) {
-            LOG.info("{} will not be read because {}", propertiesFilename, e.getMessage());
+            LOG.info("{} file not found; reading configuration from VM properties directly", propertiesFilename);
         }
         validate();
     }


### PR DESCRIPTION
Be more specific about what happens when we don't find the configuration file, instead of making it look like an error. An exception will still be thrown if required params aren't configured in either place.

By the way, VM options override configuration file settings, which may warrant a note in the readme. :book: 

Fixes #10 